### PR TITLE
Disable the Sign Up button to prevent users from double clicking and …

### DIFF
--- a/app/assets/javascripts/register.js
+++ b/app/assets/javascripts/register.js
@@ -15,8 +15,10 @@ $(document).on("turbolinks:load", function() {
         var displayError = document.getElementById("card-errors");
         if (event.error) {
           displayError.textContent = event.error.message;
+          enable_sign_up_button();
         } else {
           displayError.textContent = "";
+          enable_sign_up_button();
         }
       });
       create_stripe_token(stripe, card);
@@ -34,12 +36,17 @@ $(document).on("turbolinks:load", function() {
           // Inform the user if there was an error
           var errorElement = document.getElementById("card-errors");
           errorElement.textContent = result.error.message;
+          enable_sign_up_button();
         } else {
           // Send the token to your server
           stripeTokenHandler(result.token, form);
         }
       });
     });
+  };
+
+  var enable_sign_up_button = function() {
+    $("[data-behavior=enable_button]").prop("disabled", false).val("Sign Up")
   };
 
   var stripeTokenHandler = function(token, form) {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :require_user, only: [:show, :edit, :update]
-
+  
   def new
     @user = User.new
   end

--- a/app/views/pages/front.html.haml
+++ b/app/views/pages/front.html.haml
@@ -1,6 +1,6 @@
 %section.site_title.text-center
   %h1
-    Unlimited Movies for Only 9.99 a Month.
+    Unlimited Movies for Only $9.99 a Month.
   %h1
     = link_to "Sign Up Now!", register_path
   %p.sign_up

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -18,4 +18,4 @@
               #card-errors
         %fieldset.actions.control-group.col-sm-offset-2
           .controls
-            %input{ type: "submit", value: "Sign Up", class: "btn btn-primary" }
+            %input{ type: "submit", value: "Sign Up", class: "btn btn-primary", data: { disable_with: 'Sign Up' }, "data-behavior" => "enable_button" }


### PR DESCRIPTION
…signing up twice and enable it at appropriate times so they can still sign up when they change the form data after an unsuccessful form submission. Change 9.99 to $9.99 in the to root page title.